### PR TITLE
ENH: Add pytest cli options and ini configurations

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -68,5 +68,5 @@ jobs:
       run: |
         test_files=("scpdt/tests/module_cases.py" "scpdt/tests/stopwords_cases.py")
           for file in "${test_files[@]}"; do
-            python -m pytest "${file}" --doctest-modules
+            python -m pytest "${file}" --doctest-scpdt
           done

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -10,6 +10,29 @@ from _pytest.outcomes import skip
 from scpdt.impl import DTChecker, DTConfig, DTParser, DTFinder
 
 
+def pytest_addoption(parser):
+    """
+    Register argparse-style options and ini-style config values,
+    called once at the beginning of a test run.
+    """
+    parser.addoption(
+        "--doctest-scpt", 
+        action="store_true",
+        help="Enable doctesting for pydata libraries."
+        )
+    parser.addoption(
+        "--doctest-only", 
+        action="store_true",
+        help="Perform doctests only using the scpdt tool."
+        )
+    parser.addini(
+        "doctest_optionflags",
+        "Option flags for doctests",
+        type="args",
+        default=["NORMALIZE_WHITESPACE", "ELLIPSIS", "IGNORE_EXCEPTION_DETAIL"]
+        )
+
+
 def pytest_configure(config):
     """
     Allow plugins and conftest files to perform initial configuration.

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -2,6 +2,7 @@
 A pytest plugin that provides enhanced doctesting for Pydata libraries
 """
 
+
 from _pytest import doctest
 from _pytest.doctest import DoctestModule, DoctestTextfile
 from _pytest.pathlib import import_path
@@ -18,7 +19,9 @@ def pytest_addoption(parser):
     parser.addoption(
         "--doctest-scpt", 
         action="store_true",
-        help="Enable doctesting for pydata libraries."
+        default="False",
+        help="Enable doctesting for pydata libraries.",
+        dest="doctestscpdt"
         )
     parser.addoption(
         "--doctest-only", 
@@ -37,6 +40,8 @@ def pytest_configure(config):
     """
     Allow plugins and conftest files to perform initial configuration.
     """
+    if not config.getoption("doctestscpdt"):
+        return
 
     doctest._get_checker = _get_checker
     doctest.DoctestModule = DTModule

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -3,13 +3,17 @@ A pytest plugin that provides enhanced doctesting for Pydata libraries
 """
 
 
+import pytest
 from _pytest import doctest
 from _pytest.doctest import DoctestModule, DoctestTextfile
 from _pytest.pathlib import import_path
 from _pytest.outcomes import skip
+from pathlib import Path
+
 
 from scpdt.impl import DTChecker, DTConfig, DTParser, DTFinder
 
+pytest_version = pytest.__version__
 
 def pytest_addoption(parser):
     """
@@ -17,12 +21,12 @@ def pytest_addoption(parser):
     called once at the beginning of a test run.
     """
     parser.addoption(
-        "--doctest-scpt", 
+        "--doctest-scpdt",
         action="store_true",
-        default="False",
-        help="Enable doctesting for pydata libraries.",
+        default=False,
+        help="Run doctests in all .py modules using the scpdt tool",
         dest="doctestscpdt"
-        )
+    )
     parser.addoption(
         "--doctest-only", 
         action="store_true",
@@ -34,13 +38,18 @@ def pytest_addoption(parser):
         type="args",
         default=["NORMALIZE_WHITESPACE", "ELLIPSIS", "IGNORE_EXCEPTION_DETAIL"]
         )
+    parser.addini(
+        "doctest_scpdt",
+        help="Enable running doctests using the scpdt tool",
+        default=True
+    )
 
 
 def pytest_configure(config):
     """
     Allow plugins and conftest files to perform initial configuration.
     """
-    if not config.getoption("doctestscpdt"):
+    if not any([config.option.doctestscpdt, config.getini("doctest_scpdt")]):
         return
 
     doctest._get_checker = _get_checker
@@ -149,3 +158,4 @@ def _get_parser():
     Return instance of DTParser with default configuration
     """
     return DTParser(config=DTConfig())
+

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -12,7 +12,7 @@ Test that pytest uses the DTChecker for doctests
 def test_module_cases(pytester):
     path_str = module_cases.__file__
     python_file = PosixPath(path_str)
-    result = pytester.inline_run(python_file, "--doctest-modules")
+    result = pytester.inline_run(python_file, "--doctest-scpdt")
     assert result.ret == pytest.ExitCode.OK
 
 
@@ -21,7 +21,7 @@ def test_failure_cases(pytester):
     for file in file_list:
         path_str = file.__file__
         python_file = PosixPath(path_str)
-        result = pytester.inline_run(python_file, "--doctest-modules")
+        result = pytester.inline_run(python_file, "--doctest-scpdt")
     assert result.ret == pytest.ExitCode.TESTS_FAILED
     
 
@@ -31,5 +31,5 @@ Test that pytest uses the DTParser for doctests
 def test_stopword_cases(pytester):
     path_str = stopwords_cases.__file__
     python_file = PosixPath(path_str)
-    result = pytester.inline_run(python_file, "--doctest-modules")
+    result = pytester.inline_run(python_file, "--doctest-scpdt")
     assert result.ret == pytest.ExitCode.OK


### PR DESCRIPTION
- Implemented the `pytest_addoption` hook function to register custom cli options and ini configurations
- Updated `pyproject.toml` file with dependencies and plugin entry-point
- You can now use cli command `--doctest-scpdt` when running pytest to enable doctesting through the scpdt tool

**TODO**: 
- Bug: doctests for `*.rst` files are currently being collected twice on running: 
`python -m pytest scpdt/tests --doctest-scpdt --doctest-glob='*.rst'`
- Discuss custom cli options and  ini configurations for scpdt

Closes #67 