### PR TITLE
ENH: allow filtering out import errors on get_public_object

### DIFF
--- a/scipy_doctest/frontend.py
+++ b/scipy_doctest/frontend.py
@@ -70,8 +70,11 @@ def find_doctests(module, strategy=None,
         return tests
 
     if strategy == "api":
-        (items, names), failures = get_public_objects(module,
-                                                      skiplist=config.skiplist)
+
+        with config.user_context_mgr():
+            # user_context_mgr may want to e.g. filter warnings on imports?
+            (items, names), failures = get_public_objects(module,
+                                                          skiplist=config.skiplist)
         if failures:
             mesg = "\n".join([_[2] for _ in failures])
             raise ValueError(mesg)

--- a/scipy_doctest/util.py
+++ b/scipy_doctest/util.py
@@ -98,7 +98,7 @@ def numpy_rndm_state():
 
 
 @contextmanager
-def noop_context_mgr(test):
+def noop_context_mgr(test=None):
     """Do nothing.
 
     This is a stub context manager to serve as a default for
@@ -117,7 +117,7 @@ def np_errstate():
 
 
 @contextmanager
-def warnings_errors(test):
+def warnings_errors(test=None):
     """Temporarily turn all warnings to errors."""
     with warnings.catch_warnings():
         warnings.simplefilter('error', Warning)


### PR DESCRIPTION
get_public_object calls `getattr(module, name)`. This can emit a DeprecationWarning, so do it under config.user_context_manager() so that users can filter out these warnings.
