### PR TITLE
BUG: pytest register_assert_rewrites of internal modules

### DIFF
--- a/scipy_doctest/__init__.py
+++ b/scipy_doctest/__init__.py
@@ -5,6 +5,18 @@ Configurable, whitespace-insensitive, floating-point-aware doctest helpers.
 
 __version__ = "1.3dev0"
 
+try:
+    # register internal modules with pytest; obscure errors galore otherwise
+    import pytest
+    pytest.register_assert_rewrite(
+        "scipy_doctest.conftest", "scipy_doctest.impl", "scipy_doctest.util",
+        "scipy_doctest.frontend", "scipy_doctest.plugin"
+    )
+except ModuleNotFoundError:
+    # pytest is optional, so nothing to do
+    pass
+
+
 from .impl import DTChecker, DTFinder, DTParser, DTRunner, DebugDTRunner, DTConfig  # noqa
 from .frontend import testmod, testfile, find_doctests, run_docstring_examples      # noqa
 


### PR DESCRIPTION
Otherwise, `import scipy_doctest` emits obscure warnings from `pytest` on reimports. 