### PR TITLE
BUG: Correct filepath for doctest requiring local resource

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Test pytest plugin
       # This test will fail in a venv where scipy_doctest has not been installed and the plugin has not been activated
       run: |
-        test_files=("scipy_doctest/tests/module_cases.py" "scipy_doctest/tests/stopwords_cases.py")
+        test_files=("scipy_doctest/tests/module_cases.py" "scipy_doctest/tests/stopwords_cases.py" "scipy_doctest/tests/local_file_cases.py")
           for file in "${test_files[@]}"; do
             python -m pytest "${file}" --doctest-modules
           done

--- a/scipy_doctest/tests/local_file_cases.py
+++ b/scipy_doctest/tests/local_file_cases.py
@@ -3,7 +3,7 @@ from ..conftest import dt_config
 # Specify local files required by doctests
 dt_config.local_resources = {
     'scipy_doctest.tests.local_file_cases.local_files': ['local_file.txt'],
-    'scipy_doctest.local_file_cases.sio': ['octave_a.mat']
+    'scipy_doctest.tests.local_file_cases.sio': ['octave_a.mat']
 }
 
 

--- a/scipy_doctest/tests/test_pytest_configuration.py
+++ b/scipy_doctest/tests/test_pytest_configuration.py
@@ -49,11 +49,9 @@ def test_stopword_cases(pytester):
     assert result.ret == pytest.ExitCode.OK
 
 
-@pytest.mark.xfail(reason="XXX: passes locally, fails on CI")
 @pytest.mark.skipif(not HAVE_SCIPY, reason='need scipy')
 def test_local_file_cases(pytester):
-    """Test that local files are found for use in doctests.
-    """
+    """Test that local files are found for use in doctests."""
     path_str = local_file_cases.__file__
     python_file = Path(path_str)
     result = pytester.inline_run(python_file, "--doctest-modules")


### PR DESCRIPTION
Fixes #154 where the incorrect file path was specified for the doctest, `sio`, that required a local file, `octave_a.mat`