### PR TITLE
Stop filtering VisibleDeprecationWarning from numpy

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.11', '3.12']
-        numpy: ['"numpy<2.2"', 'numpy']
+        numpy: ['"numpy<2.0"', 'numpy']
         os:  [ubuntu-latest]
-        pytest: ['"pytest<8.0"', pytest]
+        pytest: [pytest]
         pre: ['', '--pre']
 
     steps:
@@ -36,7 +36,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install ${{matrix.pytest}} ${{matrix.pre}}
         python -m pip install -e . ${{matrix.pre}}
-        python -m pip install ${{matrix.numpy}}
+        python -m pip install ${{matrix.numpy}} ${{matrix.pre}}
 
     - name: Echo versions
       run: |

--- a/scipy_doctest/impl.py
+++ b/scipy_doctest/impl.py
@@ -9,14 +9,6 @@ import numpy as np
 
 from . import util
 
-
-## shim numpy 1.x vs 2.0
-if np.__version__ < "2":
-    VisibleDeprecationWarning = np.VisibleDeprecationWarning
-else:
-    VisibleDeprecationWarning = np.exceptions.VisibleDeprecationWarning
-
-
 # Register the optionflag to skip whole blocks, i.e.
 # sequences of Examples without an intervening text.
 SKIPBLOCK = doctest.register_optionflag('SKIPBLOCK')
@@ -331,13 +323,8 @@ class DTChecker(doctest.OutputChecker):
         # OK then, convert strings to objects
         ns = dict(self.config.check_namespace)
         try:
-            with warnings.catch_warnings():
-                # NumPy's ragged array deprecation of np.array([1, (2, 3)]);
-                # also array abbreviations: try `np.diag(np.arange(1000))`
-                warnings.simplefilter('ignore', VisibleDeprecationWarning)
-
-                a_want = eval(want, dict(ns))
-                a_got = eval(got, dict(ns))
+            a_want = eval(want, dict(ns))
+            a_got = eval(got, dict(ns))
         except Exception:
             # Maybe we're printing a numpy array? This produces invalid python
             # code: `print(np.arange(3))` produces "[0 1 2]" w/o commas between
@@ -432,12 +419,8 @@ class DTChecker(doctest.OutputChecker):
         except Exception:
             pass
 
-        with warnings.catch_warnings():
-            # NumPy's ragged array deprecation of np.array([1, (2, 3)])
-            warnings.simplefilter('ignore', VisibleDeprecationWarning)
-
-            # This line is the crux of the whole thing. The rest is mostly scaffolding.
-            result = np.allclose(want, got, atol=self.atol, rtol=self.rtol, equal_nan=True)
+        # This line is the crux of the whole thing. The rest is mostly scaffolding.
+        result = np.allclose(want, got, atol=self.atol, rtol=self.rtol, equal_nan=True)
         return result
 
 

--- a/scipy_doctest/tests/module_cases.py
+++ b/scipy_doctest/tests/module_cases.py
@@ -3,8 +3,6 @@ __all__ = [
     'func7', 'manip_printoptions', 'array_abbreviation'
 ]
 
-import numpy as np
-import pytest
 
 def func():
     """


### PR DESCRIPTION
Looks like it's no longer needed now taht we do not create object arrays for numpy array abbreviations.

While at it, tweak the CI a bit:
- enforce a run with `numpy < 2`
- stop fretting about `pytest < 8`