### PR TITLE
MAINT : stop upper capping scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies  = [
 
 [project.optional-dependencies]
 test = [
-    "scipy <= 1.14.1",   # black-list 1.5.1 ?
+    "scipy",
     "matplotlib"
 ]
 doc = [

--- a/scipy_doctest/tests/test_testmod.py
+++ b/scipy_doctest/tests/test_testmod.py
@@ -15,6 +15,7 @@ import pytest
 
 try:
     import scipy    # noqa
+    from scipy import stats   # https://github.com/scipy/scipy_doctest/issues/184
     HAVE_SCIPY = True
 except Exception:
     HAVE_SCIPY = False


### PR DESCRIPTION
Was needed to blacklist scipy==1.5.1

closes gh-184