### PR TITLE
Adapt to changes to doctest statistic tracking internals in Python 3.13

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ['3.11', '3.12', '3.13']
         numpy: ['"numpy<2.0"', "numpy"]
         os: [ubuntu-latest]
         pytest: [pytest]

--- a/scipy_doctest/impl.py
+++ b/scipy_doctest/impl.py
@@ -4,6 +4,7 @@ import inspect
 import doctest
 from doctest import NORMALIZE_WHITESPACE, ELLIPSIS, IGNORE_EXCEPTION_DETAIL
 from itertools import zip_longest
+from sys import version_info
 
 import numpy as np
 
@@ -518,7 +519,10 @@ class DTRunner(doctest.DocTestRunner):
         an object, and the value is a tuple of the numbers of examples which
         failed and which were tried.
         """
-        return self._name2ft
+        if version_info >= (3, 13):
+            return self._stats
+        else:
+            return self._name2ft
 
 
 class DebugDTRunner(DTRunner):

--- a/scipy_doctest/impl.py
+++ b/scipy_doctest/impl.py
@@ -515,9 +515,10 @@ class DTRunner(doctest.DocTestRunner):
     def get_history(self):
         """Return a dict with names of items which were run.
 
-        Actually the dict is `{name : (f, t)}`, where `name` is the name of
-        an object, and the value is a tuple of the numbers of examples which
-        failed and which were tried.
+        Actually the dict is `{name : (failures, tries, skips)}` (before Python
+        3.13, just `{name : (failures, tries, skips)}`) where `name` is the
+        name of an object, and the value is a tuple of the numbers of examples
+        which failed, were tried, and were skipped, respectively.
         """
         if version_info >= (3, 13):
             return self._stats

--- a/scipy_doctest/tests/test_skipmarkers.py
+++ b/scipy_doctest/tests/test_skipmarkers.py
@@ -1,4 +1,5 @@
 import doctest
+from sys import version_info
 
 try:
     import matplotlib.pyplot as plt    # noqa
@@ -57,7 +58,8 @@ class TestSyntaxErrors:
                                    lineno=0)
         runner = DebugDTRunner()
         runner.run(test)
-        assert runner.get_history() == {'none : +SKIP': (0, 0)}
+        stats = (0, 1, 1) if version_info >= (3, 13) else (0, 0)
+        assert runner.get_history() == {'none : +SKIP': stats}
 
     def test_invalid_python_pseudocode(self):
         # Marking a test as pseudocode is equivalent to a +SKIP:
@@ -74,7 +76,8 @@ class TestSyntaxErrors:
                                    lineno=0)
         runner = DebugDTRunner()
         runner.run(test)
-        assert runner.get_history() == {'none : pseudocode': (0, 0)}
+        stats = (0, 1, 1) if version_info >= (3, 13) else (0, 0)
+        assert runner.get_history() == {'none : pseudocode': stats}
 
 
 class TestPseudocodeMarkers:
@@ -125,7 +128,8 @@ class TestStopwords:
         runner.run(test)
 
         # one example tried, of which zero failed
-        assert runner.get_history() == {'stopwords_bogus_output': (0, 1)}
+        stats = (0, 1, 0) if version_info >= (3, 13) else (0, 1)
+        assert runner.get_history() == {'stopwords_bogus_output': stats}
 
 
 class TestMayVary:
@@ -148,7 +152,8 @@ class TestMayVary:
         runner.run(test)
 
         # one example tried, of which zero failed
-        assert runner.get_history() == {'may_vary_markers': (0, 1)}
+        stats = (0, 1, 0) if version_info >= (3, 13) else (0, 1)
+        assert runner.get_history() == {'may_vary_markers': stats}
 
     def test_may_vary_source(self):
         # The marker needs to be added to the example output, not source.
@@ -164,7 +169,8 @@ class TestMayVary:
         runner.run(test)
 
         # one example tried, of which zero failed
-        assert runner.get_history() == {'may_vary_source': (0, 1)}
+        stats = (0, 1, 0) if version_info >= (3, 13) else (0, 1)
+        assert runner.get_history() == {'may_vary_source': stats}
 
     def test_may_vary_syntax_error(self):
         # `# may vary` markers do not mask syntax errors, unlike `# doctest: +SKIP`


### PR DESCRIPTION
This is a ~~partial~~ now hopefully complete fix for https://github.com/scipy/scipy_doctest/issues/191. See https://github.com/python/cpython/commit/4f9b706c6f5d4422a398146bfd011daedaef1851.