### PR TITLE
ENH: make dicts with string keys use numeric comparisons

### DIFF
--- a/scipy_doctest/impl.py
+++ b/scipy_doctest/impl.py
@@ -422,10 +422,13 @@ class DTChecker(doctest.OutputChecker):
             return False
 
         if want_is_dict:
-            # convert dicts into lists of key-value pairs and retry
-            want_items = str(list(a_want.items()))
-            got_items = str(list(a_got.items()))
-            return self.check_output(want_items, got_items, optionflags)
+            # split each dict into a pair of lists of keys and values, and retry
+            want_keys, want_values = f"{list(a_want.keys())}", f"{list(a_want.values())}"
+            got_keys, got_values = f"{list(a_got.keys())}", f"{list(a_got.values())}"
+
+            keys_match = self.check_output(want_keys, got_keys, optionflags)
+            values_match = self.check_output(want_values, got_values, optionflags)
+            return keys_match and values_match
 
         # ... and defer to numpy
         strict = self.config.strict_check

--- a/scipy_doctest/tests/failure_cases.py
+++ b/scipy_doctest/tests/failure_cases.py
@@ -86,7 +86,7 @@ def dict_wrong_values_np():
     """
     >>> import numpy as np
     >>> dict(a=1, b=np.arange(3)/3)
-    {'a': 1, 'b': array([0, 0.335, 0.669])}
+    {'a': 1, 'b': array([0, 0.335, 0.69])}
     """
 
 
@@ -94,5 +94,25 @@ def dict_nested_wrong_values_np():
     """
     >>> import numpy as np
     >>> dict(a=1, b=dict(blurb=np.arange(3)/3))
-    {'a': 1, 'b': {'blurb': array([0, 0.335, 0.669])}}
+    {'a': 1, 'b': {'blurb': array([0, 0.335, 0.69])}}
+    """
+
+
+# This is an XFAIL
+# Currently, checking nested dicts falls back to vanilla doctest
+# When this is fixed, move this case to module_cases.py
+def dict_nested_needs_numeric_comparison():
+    """
+    >>> import numpy as np
+    >>> dict(a=1, b=dict(blurb=np.arange(3)/3))
+    {'a': 1, 'b': {'blurb': array([0, 0.333, 0.667])}}
+    """
+
+
+# This is an XFAIL
+# Nested sequences which contain strings fall back to vanilla doctest
+def list_of_tuples():
+    """
+    >>> [('a', 1/3), ('b', 2/3)]
+    [('a', 0.333), ('b', 0.667)]
     """

--- a/scipy_doctest/tests/module_cases.py
+++ b/scipy_doctest/tests/module_cases.py
@@ -249,14 +249,26 @@ def two_dicts():
     >>> import numpy as np
     >>> dict(a=0, b=1)
     {'a': 0, 'b': 1}
+    >>> {'a': 1/3, 'b': 2/3}
+    {'a': 0.333, 'b': 0.667}
     >>> {'a': 0., 'b': np.arange(3) / 3 }
-    {'a': 0.0, 'b': array([0, 0.33333333, 0.66666667])}
+    {'a': 0.0, 'b': array([0, 0.333, 0.667])}
     """
 
 def nested_dicts():
+    # Note that we need to give all digits: checking nested dictionaries
+    # currently fall back to vanilla doctest.
+    # cf failure_cases.py::dict_nested_needs_numeric_comparison
     """
     >>> import numpy as np
     >>> {'a': 1.0, 'b': dict(blurb=np.arange(3)/3)}
     {'a': 1.0, 'b': {'blurb': array([0, 0.33333333, 0.66666667])}}
     """
 
+
+def list_of_tuples_numeric():
+    # cf failure_cases.py::list_of_tuples --- string entries preclude numeric comparisons
+    """
+    >>> [(1, 1/3), (2, 2/3)]
+    [(1, 0.333), (2, 0.667)]
+    """

--- a/scipy_doctest/tests/test_testmod.py
+++ b/scipy_doctest/tests/test_testmod.py
@@ -117,6 +117,15 @@ def test_tuple_and_list():
                       config=config)
     assert res.failed == 2
 
+
+def test_list_of_tuples():
+    config = DTConfig()
+    res, _ = _testmod(failure_cases,
+                      strategy=[failure_cases.list_of_tuples],
+                      config=config)
+    assert res.failed == 1
+
+
 def test_dict():
     config = DTConfig()
     res, _ = _testmod(failure_cases,
@@ -125,9 +134,11 @@ def test_dict():
                                 failure_cases.dict_wrong_keys,
                                 failure_cases.dict_wrong_values,
                                 failure_cases.dict_wrong_values_np,
-                                failure_cases.dict_nested_wrong_values_np],
+                                failure_cases.dict_nested_wrong_values_np,
+                                failure_cases.dict_nested_needs_numeric_comparison,
+                      ],
                       config=config)
-    assert res.failed == 6
+    assert res.failed == 7
 
 
 @pytest.mark.parametrize('strict, num_fails', [(True, 1), (False, 0)])


### PR DESCRIPTION
Previously, these cases would fall back to vanilla pytest.
    
The problem is two-fold:
    1. `np.allclose('a', 'a')` fails with a `DTypePromotionError`;
    2. Our recursive treatment of nested data structures is limited.  It fails to parse `[('a', 2), ('b', 3)]` and falls back to the
         vanilla doctest.
    
Therefore, we handle dictionaries by checking the keys and values separately, instead of trying to convert a dict into a list of pairs.

cross-ref gh-202