### PR TITLE
Add `pytest_extra_requires` to conditionally ignore paths unless requirements are met

### DIFF
--- a/scipy_doctest/impl.py
+++ b/scipy_doctest/impl.py
@@ -79,7 +79,7 @@ class DTConfig:
         Default is False.
     pytest_extra_ignore : list
         A list of names/modules to ignore when run under pytest plugin. This is
-        equivalent to using `--ignore=...` cmdline switch.
+        equivalent to using ``--ignore=...`` cmdline switch.
     pytest_extra_skip : dict
         Names/modules to skip when run under pytest plugin. This is
         equivalent to decorating the doctest with `@pytest.mark.skip` or adding
@@ -92,6 +92,11 @@ class DTConfig:
         adding `# may vary` to the outputs of all examples.
         Each key is a doctest name to skip, and the corresponding value is
         a string. If not empty, the string value is used as the skip reason.
+    pytest_extra_requires : dict
+        Paths to conditionally ignore unless requirements are met.
+        The format is ``{path/or/glob/pattern: requirement}``, where the values are
+        PEP 508 dependency specifiers. If a requirement is not met, the behavior
+        is equivalent to using the ``--ignore=...`` command line switch.
     CheckerKlass : object, optional
         The class for the Checker object. Must mimic the ``DTChecker`` API:
         subclass the `doctest.OutputChecker` and make the constructor signature
@@ -125,6 +130,7 @@ class DTConfig:
                           pytest_extra_ignore=None,
                           pytest_extra_skip=None,
                           pytest_extra_xfail=None,
+                          pytest_extra_requires=None,
     ):
         ### DTChecker configuration ###
         self.CheckerKlass = CheckerKlass or DTChecker
@@ -217,6 +223,7 @@ class DTConfig:
         self.pytest_extra_ignore = pytest_extra_ignore or []
         self.pytest_extra_skip = pytest_extra_skip or {}
         self.pytest_extra_xfail = pytest_extra_xfail or {}
+        self.pytest_extra_requires = pytest_extra_requires or {}
 
 
 def try_convert_namedtuple(got):

--- a/scipy_doctest/plugin.py
+++ b/scipy_doctest/plugin.py
@@ -5,6 +5,9 @@ import bdb
 import warnings
 import doctest
 
+from importlib.metadata import version as get_version, PackageNotFoundError
+from packaging.requirements import Requirement
+
 import pytest
 import _pytest
 from _pytest import doctest as pydoctest, outcomes
@@ -83,9 +86,19 @@ def pytest_ignore_collect(collection_path, config):
             return True
 
     fnmatch_ex = _pytest.pathlib.fnmatch_ex
+
     for entry in config.dt_config.pytest_extra_ignore:
         if fnmatch_ex(entry, collection_path):
             return True
+
+    for entry, req_str in config.dt_config.pytest_extra_requires.items():
+        if fnmatch_ex(entry, collection_path):
+            # check the requirement
+            req = Requirement(req_str)
+            try:
+                return not (get_version(req.name) in req.specifier)
+            except PackageNotFoundError:
+                return True
 
 
 def is_private(item):

--- a/scipy_doctest/plugin.py
+++ b/scipy_doctest/plugin.py
@@ -82,8 +82,9 @@ def pytest_ignore_collect(collection_path, config):
         if "tests" in path_str or "test_" in path_str:
             return True
 
+    fnmatch_ex = _pytest.pathlib.fnmatch_ex
     for entry in config.dt_config.pytest_extra_ignore:
-        if entry in str(collection_path):
+        if fnmatch_ex(entry, collection_path):
             return True
 
 


### PR DESCRIPTION
fixes gh-197

```
dt_config = DTConfig()

dt_config.pytest_extra_requires = {
   "path/to/file" : "cupy>=2.3.4"
}
```

Potential follow-ups

- [ ] `spin`-made dev builds do not play nice with `packaging.requirements.version`. Can add a fallback to `__version__`. This is only relevant if a spin-built package is a dependency, so this should be very rare. Probably not worth bothering until a there's a real use case.
- [ ] allow setting per-doctest requirements: `{"module.func": "cupy>2.3.4"}`, similar to `pytest_extra_ignore`